### PR TITLE
Fix invalid URL escape

### DIFF
--- a/main.go
+++ b/main.go
@@ -632,7 +632,7 @@ Loop:
 			}
 		}
 
-		u, err := url.Parse(line[c.UriLabel])
+		u, err := url.Parse(url.QueryEscape(line[c.UriLabel]))
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/main.go
+++ b/main.go
@@ -439,7 +439,7 @@ var (
 
 func main() {
 	kingpin.CommandLine.Help = "Access Log Profiler for LTSV (read from file or stdin)."
-	kingpin.Version("0.2.2")
+	kingpin.Version("0.2.3")
 	kingpin.Parse()
 
 	var f *os.File


### PR DESCRIPTION
Fix invalid URL escape (https://github.com/tkuchiki/alp/issues/1)  

```
cat /tmp/bad.log | ./alp --apptime-label reqtime
+-------+-------+-------+-------+-------+-------+-------+-------+--------+-----------+-----------+-----------+-----------+--------+------------------------------------------------------------------------------------------------------+
| COUNT |  MIN  |  MAX  |  SUM  |  AVG  |  P1   |  P50  |  P99  | STDDEV | MIN(BODY) | MAX(BODY) | SUM(BODY) | AVG(BODY) | METHOD |                                                 URI                                                  |
+-------+-------+-------+-------+-------+-------+-------+-------+--------+-----------+-----------+-----------+-----------+--------+------------------------------------------------------------------------------------------------------+
| 1     | 0.000 | 0.000 | 0.000 | 0.000 | 0.000 | 0.000 | 0.000 |  0.000 |     0.000 |     0.000 |     0.000 |     0.000 | GET    | /css/main.css?1000                                                                                   |
| 1     | 0.000 | 0.000 | 0.000 | 0.000 | 0.000 | 0.000 | 0.000 |  0.000 |     0.000 |     0.000 |     0.000 |     0.000 | GET    | /images/kali.jpg                                                                                     |
| 1     | 0.000 | 0.000 | 0.000 | 0.000 | 0.000 | 0.000 | 0.000 |  0.000 |  3255.000 |  3255.000 |  3255.000 |  3255.000 | GET    | /2015/12/vagrantfiles_for_php7.html                                                                  |
| 1     | 0.000 | 0.000 | 0.000 | 0.000 | 0.000 | 0.000 | 0.000 |  0.000 |  3486.000 |  3486.000 |  3486.000 |  3486.000 | GET    | /2013/04/c_kr_stack.html                                                                             |
| 1     | 0.022 | 0.022 | 0.022 | 0.022 | 0.022 | 0.022 | 0.022 |  0.000 | 31506.000 | 31506.000 | 31506.000 | 31506.000 | GET    | /                                                                                                    |
| 1     | 1.206 | 1.206 | 1.206 | 1.206 | 1.206 | 1.206 | 1.206 |  0.000 |   168.000 |   168.000 |   168.000 |   168.000 | GET    | /server-status?HTTP_POST=%\x22%6346#%#/&#736%\x22#423|;&HTTP_CGI_GET=GRESYYK\x22K&J\x22#L523D2G23H23 |
+-------+-------+-------+-------+-------+-------+-------+-------+--------+-----------+-----------+-----------+-----------+--------+------------------------------------------------------------------------------------------------------+
```