### PR TITLE
Omitting a key when using the -c option does not cause panic

### DIFF
--- a/options/option.go
+++ b/options/option.go
@@ -533,7 +533,7 @@ func LoadOptionsFromReader(r io.Reader) (*Options, error) {
 		return opts, err
 	}
 
-	configs := &Options{}
+	configs := NewOptions()
 	err = yaml.Unmarshal(buf, configs)
 
 	opts = SetOptions(opts,


### PR DESCRIPTION
Fix #53 