### PR TITLE
Fix matching groups behavior

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -424,6 +424,7 @@ sample は [Usage samples](./docs/usage_samples.ja.md) を参照してくださ�
     - デフォルトはすべて出力(`all`)
 - `-m, --matching-groups=PATTERN,...`
     - 正規表現にマッチした URI を同じ集計対象として扱います
+    - 指定した順序で正規表現を評価します。マッチした場合、それ以降の正規表現を評価しません。
     - 後述の [URI matching groups](#uri-matching-groups) 参照
 - `-f, --filters=FILTERS`
     - 集計対象をフィルタします

--- a/README.md
+++ b/README.md
@@ -415,6 +415,7 @@ See: [Usage samples](./docs/usage_samples.md)
     - The default is `all`
 - `-m, --matching-groups=PATTERN,...`
     - Treat URIs that match regular expressions as the same URI
+    - Evaluate in the specified order. If matched, no further evaluation is performed.
     - See [URI matching groups](#uri-matching-groups)
 - `-f, --filters=FILTERS`
     - Filters the targets for profile

--- a/alp.go
+++ b/alp.go
@@ -18,7 +18,7 @@ import (
 	"gopkg.in/alecthomas/kingpin.v2"
 )
 
-const version = "1.0.7"
+const version = "1.0.8"
 
 type Profiler struct {
 	outWriter    io.Writer

--- a/stats/stats.go
+++ b/stats/stats.go
@@ -65,6 +65,7 @@ func (hs *HTTPStats) Set(uri, method string, status int, restime, resBodyBytes, 
 			if ok := re.Match([]byte(uri)); ok {
 				pattern := re.String()
 				uri = pattern
+				break
 			}
 		}
 	}


### PR DESCRIPTION
SSIA

> Evaluate in the specified order. If matched, no further evaluation is performed