### PR TITLE
fix duplication of config yaml

### DIFF
--- a/options/option.go
+++ b/options/option.go
@@ -62,7 +62,7 @@ var DefaultPcapServerIPsOption = getDefaultPcapServerIPsOption()
 type Options struct {
 	File                    string         `yaml:"file"`
 	Dump                    string         `yaml:"dump"`
-	Load                    string         `yaml:"dump"`
+	Load                    string         `yaml:"load"`
 	Sort                    string         `yaml:"sort"`
 	Reverse                 bool           `yaml:"reverse"`
 	QueryString             bool           `yaml:"query_string"`


### PR DESCRIPTION
We get error when using config file with `--config` option, like this.

```alp ltsv  --config alp.yaml
panic: Duplicated key 'dump' in struct options.Options [recovered]
	panic: Duplicated key 'dump' in struct options.Options

goroutine 1 [running]:
gopkg.in/yaml%2ev2.handleErr(0xc0001d90a8)
	gopkg.in/yaml.v2@v2.4.0/yaml.go:249 +0x6d
panic({0x828e40, 0xc0001df370})
	runtime/panic.go:838 +0x207
gopkg.in/yaml%2ev2.(*decoder).mappingStruct(0xc0000628a0, 0xc000211ab0, {0x891000?, 0xc00008f440?, 0x4?})
	gopkg.in/yaml.v2@v2.4.0/decode.go:727 +0xcd1
gopkg.in/yaml%2ev2.(*decoder).mapping(0x80ab60?, 0xc000211ab0?, {0x891000?, 0xc00008f440?, 0x0?})
	gopkg.in/yaml.v2@v2.4.0/decode.go:626 +0x45f
gopkg.in/yaml%2ev2.(*decoder).unmarshal(0xc0000628a0, 0xc000211ab0, {0x891000?, 0xc00008f440?, 0x1000000000030?})
	gopkg.in/yaml.v2@v2.4.0/decode.go:372 +0x16c
gopkg.in/yaml%2ev2.(*decoder).document(0xc000211a40?, 0xc000211ab0?, {0x891000?, 0xc00008f440?, 0xc000226c00?})
	gopkg.in/yaml.v2@v2.4.0/decode.go:384 +0x5d
gopkg.in/yaml%2ev2.(*decoder).unmarshal(0x80a720?, 0xc00008f440?, {0x891000?, 0xc00008f440?, 0xc00008f440?})
	gopkg.in/yaml.v2@v2.4.0/decode.go:360 +0x196
gopkg.in/yaml%2ev2.unmarshal({0xc00022a000, 0x1f9, 0x200}, {0x80a720?, 0xc00008f440}, 0x0)
	gopkg.in/yaml.v2@v2.4.0/yaml.go:148 +0x406
gopkg.in/yaml%2ev2.Unmarshal(...)
	gopkg.in/yaml.v2@v2.4.0/yaml.go:81
github.com/tkuchiki/alp/options.LoadOptionsFromReader({0x969360, 0xc00000e9c8})
	github.com/tkuchiki/alp/options/option.go:566 +0xb9
github.com/tkuchiki/alp/cmd/alp/cmd.createOptions(0x833700?, 0xc000061500)
	github.com/tkuchiki/alp/cmd/alp/cmd/option.go:168 +0x590
github.com/tkuchiki/alp/cmd/alp/cmd.NewLTSVCmd.func1(0xc000216300?, {0x89cd0b?, 0x2?, 0x2?})
	github.com/tkuchiki/alp/cmd/alp/cmd/ltsv.go:21 +0x4a5
github.com/spf13/cobra.(*Command).execute(0xc000216300, {0xc0000614a0, 0x2, 0x2})
	github.com/spf13/cobra@v1.7.0/command.go:940 +0x862
github.com/spf13/cobra.(*Command).ExecuteC(0xc000216000)
	github.com/spf13/cobra@v1.7.0/command.go:1068 +0x3bc
github.com/spf13/cobra.(*Command).Execute(...)
	github.com/spf13/cobra@v1.7.0/command.go:992
github.com/tkuchiki/alp/cmd/alp/cmd.Execute({0x967358?, 0x0?})
	github.com/tkuchiki/alp/cmd/alp/cmd/root.go:39 +0x25
main.main()
	./main.go:12 +0x27
```

The cause is duplication of `dump` key in `Options` struct.

This PR fixes the duplication.